### PR TITLE
Fixing problems for small sample sizes and binary covariates

### DIFF
--- a/R/maxstat.R
+++ b/R/maxstat.R
@@ -90,10 +90,14 @@ pLausen94 <- function(b, N, minprop=0.1, maxprop=0.9, m=NULL)
 {
   if(is.null(m))
     m <- floor(N*minprop):floor(N*maxprop)
-  m1 <- m[1:(length(m)-1)]
-  m2 <- m[2:length(m)]
-  t <- sqrt(1 - m1*(N-m2)/((N-m1)*m2))
-  D <- sum(1/pi*exp(-b^2/2)*(t - (b^2/4 -1)*(t^3)/6))
+  if (length(m) == 1) { 
+    D <- 0
+  } else {
+    m1 <- m[1:(length(m)-1)]
+    m2 <- m[2:length(m)]
+    t <- sqrt(1 - m1*(N-m2)/((N-m1)*m2))
+    D <- sum(1/pi*exp(-b^2/2)*(t - (b^2/4 -1)*(t^3)/6))
+  }
   1 - (pnorm(b) - pnorm(-b)) + D
 }
 

--- a/R/maxstat.test.R
+++ b/R/maxstat.test.R
@@ -160,7 +160,7 @@ cmaxstat <- function(y, x=NULL, weights = NULL,
   if (minprop == 0 & maxprop==1) m <- m[2:(length(m)-1)] else {
     if (all(m < floor(N*minprop))) stop("minprop too large")
     if (all(m > floor(N*maxprop))) stop("maxprop too small")
-    m <- m[m >= floor(N*minprop)]
+    m <- m[m >= max(1, floor(N*minprop))]
     m <- m[m <= floor(N*maxprop)]
   }
 


### PR DESCRIPTION
First commit:
Force m to be at least 1. For sample sizes smaller than 1/minprop, floor(N*minprop) would be 0, allowing 0 in m (which is used as index later). 

Second commit: 
In the Lau94 approximation the sum (D in the code) should be 0 for k=1. This was not implemented in the package. 
